### PR TITLE
Workflows to check the upstream kubernetes releases

### DIFF
--- a/.github/workflows/nightly-k8s-release-check.yml
+++ b/.github/workflows/nightly-k8s-release-check.yml
@@ -1,0 +1,94 @@
+name: nightly-k8s-release-check
+
+on:
+  schedule:
+    # "Minute [0,59]" "Hour [0,23]" "Day of the month [1,31]" "Month of the year [1,12]" "Day of the week ([0,6] with 0=Sunday)"
+    - cron: '0 0 * * 2-6'
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check latest releases
+        uses: actions/github-script@v4.0.2
+        with:
+          script: |
+            (async () => {
+              const [releases, prs] = await Promise.all([
+                github.repos.listReleases({
+                  owner: "kubernetes",
+                  repo: "kubernetes",
+                  per_page: 30,
+                  page: 1,
+                }),
+                github.issues.listForRepo({
+                  owner: "cloudtogo",
+                  repo: "containerized-kubelet",
+                  state: "all",
+                  per_page: 30,
+                  page: 1,
+                }),
+              ]);
+
+              var issueLabels = {};
+              if (prs.status != 200) {
+                console.error("[pr] http failure %d", prs.status);
+                throw new Error("http failure");
+              }
+
+              for (const pr of prs.data) {
+                if (pr.labels.length > 0) {
+                  for (const label of pr.labels) {
+                    issueLabels[label.name] = true;
+                  }
+                  break;
+                }
+              }
+
+              if (issueLabels.length == 0) {
+                console.error("no label found in PR");
+                throw new Error("no label found in PR");
+              }
+
+              console.log("PR labels ", issueLabels);
+              
+              if (releases.status != 200) {
+                console.error("[kubernetes] http failure %d", releases.status);
+                throw new Error("http failure");
+              }
+
+              var newReleases = [];
+              var latestRel = "";
+              for (const rel of releases.data) {
+                if (!rel.rel && rel.tag_name.match(/^v\d+\.\d+\.\d+$/)) {
+                  if (issueLabels[rel.tag_name]) {
+                    break;
+                  }
+
+                  console.log("found release %s", rel.name);
+                  newReleases.push(rel.tag_name);
+                  if (latestRel == "") {
+                    latestRel = rel.tag_name;
+                  }
+                }
+              }
+
+              console.log("New releases ", newReleases);
+
+              const newIssue = await github.issues.create({
+                owner: "cloudtogo",
+                repo: "containerized-kubelet",
+                title: "Build images for upgrade upstream LTS",
+                labels: newReleases.map((rel) => rel),
+                body: "This issue is created by a periodically running robot, for building images of the latest kubernetes LTS.",
+              });
+              if (newIssue.status != 201) {
+                console.error("[new issue] http failure %d", newIssue.status);
+                throw new Error("http failure");
+              }
+
+              console.log("Issue for %s created", releases);
+            })();

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .vagrant
 *.log
+node_modules

--- a/hack/github/package-lock.json
+++ b/hack/github/package-lock.json
@@ -1,0 +1,328 @@
+{
+  "name": "github",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@octokit/rest": "^18.7.2"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.2.0.tgz",
+      "integrity": "sha512-c4A1Xm0At+ypvBfEETREu519wLncJYQXvY+dBGg/V5YA51eg5EwdDsPPfcOMG0cuXscqRvsIgIySTmTJUdcTNA=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.14.0.tgz",
+      "integrity": "sha512-S2uEu2uHeI7Vf+Lvj8tv3O5/5TCAa8GHS0dUQN7gdM7vKA6ZHAbR6HkAVm5yMb1mbedLEbxOuQ+Fa0SQ7tCDLA==",
+      "dependencies": {
+        "@octokit/types": "^6.18.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.5.2.tgz",
+      "integrity": "sha512-1ArooY7AYQdUd2zyqWLFHQ6gver9PvZSiuM+EPAsDplv1Y6u8zHl6yZ7yGIgaf7xvWupwUkJS2WttGYyb1P0DQ==",
+      "dependencies": {
+        "@octokit/types": "^6.22.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.7.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.7.2.tgz",
+      "integrity": "sha512-TAedgLqNRS+rdGqS9v00sqBeS6IgyLSoqqCDu6pmoadAB7xSjFHShxzaXUAbxxJjyHtb7mencRGzgH4W/V6Myg==",
+      "dependencies": {
+        "@octokit/core": "^3.5.0",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.5.2"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.22.0.tgz",
+      "integrity": "sha512-Y8GR0BJHQDpO09qw/ZQpN+DXrFzCWaE0pvK4frDm3zJ+h99AktsFfBoDazbCtHxiL8d0jD8xRH4BeynlKLeChg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^9.2.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  },
+  "dependencies": {
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.0",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.2.0.tgz",
+      "integrity": "sha512-c4A1Xm0At+ypvBfEETREu519wLncJYQXvY+dBGg/V5YA51eg5EwdDsPPfcOMG0cuXscqRvsIgIySTmTJUdcTNA=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.14.0.tgz",
+      "integrity": "sha512-S2uEu2uHeI7Vf+Lvj8tv3O5/5TCAa8GHS0dUQN7gdM7vKA6ZHAbR6HkAVm5yMb1mbedLEbxOuQ+Fa0SQ7tCDLA==",
+      "requires": {
+        "@octokit/types": "^6.18.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "requires": {}
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.5.2.tgz",
+      "integrity": "sha512-1ArooY7AYQdUd2zyqWLFHQ6gver9PvZSiuM+EPAsDplv1Y6u8zHl6yZ7yGIgaf7xvWupwUkJS2WttGYyb1P0DQ==",
+      "requires": {
+        "@octokit/types": "^6.22.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.7.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.7.2.tgz",
+      "integrity": "sha512-TAedgLqNRS+rdGqS9v00sqBeS6IgyLSoqqCDu6pmoadAB7xSjFHShxzaXUAbxxJjyHtb7mencRGzgH4W/V6Myg==",
+      "requires": {
+        "@octokit/core": "^3.5.0",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "5.5.2"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.22.0.tgz",
+      "integrity": "sha512-Y8GR0BJHQDpO09qw/ZQpN+DXrFzCWaE0pvK4frDm3zJ+h99AktsFfBoDazbCtHxiL8d0jD8xRH4BeynlKLeChg==",
+      "requires": {
+        "@octokit/openapi-types": "^9.2.0"
+      }
+    },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/hack/github/package.json
+++ b/hack/github/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@octokit/rest": "^18.7.2"
+  }
+}

--- a/hack/github/upstream-check.js
+++ b/hack/github/upstream-check.js
@@ -1,0 +1,89 @@
+const { Octokit } = require("@octokit/rest");
+
+const octokit = new Octokit({
+	auth: "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",
+	previews: ['jean-grey', 'symmetra'],
+	log: {
+	    debug: () => {},
+	    info: console.log,
+	    warn: console.warn,
+	    error: console.error
+	 },
+});
+
+(async () => {
+	const [releases, prs] = await Promise.all([
+		octokit.rest.repos.listReleases({
+			owner: "kubernetes",
+			repo: "kubernetes",
+			per_page: 30,
+			page: 1,
+		}),
+		octokit.rest.issues.listForRepo({
+			owner: "cloudtogo",
+			repo: "containerized-kubelet",
+			state: "all",
+			per_page: 30,
+			page: 1,
+		}),
+	]);
+
+	var issueLabels = {};
+	if (prs.status != 200) {
+		console.error("[pr] http failure %d", prs.status);
+		throw new Error("http failure");
+	}
+
+	for (const pr of prs.data) {
+		if (pr.labels.length > 0) {
+			for (const label of pr.labels) {
+				issueLabels[label.name] = true;
+			}
+			break;
+		}
+	}
+
+	if (issueLabels.length == 0) {
+		console.error("no label found in PR");
+		throw new Error("no label found in PR");
+	}
+
+	console.log("PR labels ", issueLabels);
+	
+	if (releases.status != 200) {
+		console.error("[kubernetes] http failure %d", releases.status);
+		throw new Error("http failure");
+	}
+
+	var newReleases = [];
+	var latestRel = "";
+	for (const rel of releases.data) {
+		if (!rel.rel && rel.tag_name.match(/^v\d+\.\d+\.\d+$/)) {
+			if (issueLabels[rel.tag_name]) {
+				break;
+			}
+
+			console.log("found release %s", rel.name);
+			newReleases.push(rel.tag_name);
+			if (latestRel == "") {
+				latestRel = rel.tag_name;
+			}
+		}
+	}
+
+	console.log("New releases ", newReleases);
+
+	const newIssue = await octokit.rest.issues.create({
+		owner: "cloudtogo",
+		repo: "containerized-kubelet",
+		title: "Build images for upgrade upstream LTS",
+		labels: newReleases.map((rel) => rel),
+		body: "This issue is created by a periodically running robot, for building images of the latest kubernetes LTS.",
+	});
+	if (newIssue.status != 201) {
+		console.error("[new issue] http failure %d", newIssue.status);
+		throw new Error("http failure");
+	}
+
+	console.log("Issue for %s created", releases);
+})();

--- a/test/k8s-e2e/Vagrantfile
+++ b/test/k8s-e2e/Vagrantfile
@@ -161,11 +161,20 @@ Vagrant.configure("2") do |config|
         master.vm.provision :file, source: "flannel.yaml", destination: "/home/vagrant/flannel.yaml"
         kubeCli="/tmp/kubernetes-client-linux-amd64.tar.gz"
         if !File.file?(kubeCli)
-            `curl -skL https://storage.googleapis.com/kubernetes-release/release/v1.21.2/kubernetes-client-linux-amd64.tar.gz -o /tmp/kubernetes-client-linux-amd64.tar.gz`
-            `tar zxf /tmp/kubernetes-client-linux-amd64.tar.gz -C /tmp`
+            `curl -skL https://storage.googleapis.com/kubernetes-release/release/v1.21.2/kubernetes-client-linux-amd64.tar.gz -o #{kubeCli}`
+            `tar zxf #{kubeCli} -C /tmp`
         end
         master.vm.provision :file, source: "/tmp/kubernetes/client/bin/kubectl", destination: "/tmp/kubectl"
         master.vm.provision :shell, inline: "mv /tmp/kubectl /usr/local/bin/"
+        
+        sonobuoy = "/tmp/sonobuoy.tar.gz"
+        if !File.file?(sonobuoy)
+            `curl -skL https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.52.0/sonobuoy_0.52.0_linux_amd64.tar.gz -o #{sonobuoy}`
+            `tar zxf #{sonobuoy} -C /tmp`
+        end
+        master.vm.provision :file, source: "/tmp/sonobuoy", destination: "/tmp/sonobuoy"
+        master.vm.provision :shell, inline: "mv /tmp/sonobuoy /usr/local/bin/"
+
         master.vm.provision :shell, path: "e2e-master.sh"
       else
         master.vm.provision :shell, path: "e2e-node.sh"

--- a/test/k8s-e2e/e2e-master.sh
+++ b/test/k8s-e2e/e2e-master.sh
@@ -10,6 +10,9 @@ docker pull ${IMAGE}
 
 mkdir -p /etc/kubernetes /etc/cni/net.d /var/lib/kubelet /var/log/pods
 
+# For flannel
+mkdir -p /run/flannel
+
 echo "starting kubelet"
 docker run -d --restart=always --name=kubeletd --network=host --pid=host --uts=host --privileged \
     -v /etc/machine-id:/etc/machine-id -v /var/lib/dbus/machine-id:/var/lib/dbus/machine-id \
@@ -21,6 +24,7 @@ docker run -d --restart=always --name=kubeletd --network=host --pid=host --uts=h
     --mount type=bind,src=/var/lib/kubelet,dst=/var/lib/kubelet,bind-propagation=rshared \
     -v /var/log/pods:/var/log/pods \
     -v /etc/kubernetes:/etc/kubernetes -v /etc/cni/net.d:/etc/cni/net.d \
+    -v /run/flannel:/run/flannel \
     ${IMAGE}
 
 echo "starting kubeadm"

--- a/test/k8s-e2e/e2e-node.sh
+++ b/test/k8s-e2e/e2e-node.sh
@@ -10,6 +10,9 @@ docker pull ${IMAGE}
 
 mkdir -p /etc/kubernetes /etc/cni/net.d /var/lib/kubelet /var/log/pods
 
+# For flannel
+mkdir -p /run/flannel
+
 echo "starting kubelet"
 docker run -d --restart=always --name=kubeletd --network=host --pid=host --uts=host --privileged \
     -v /etc/machine-id:/etc/machine-id -v /var/lib/dbus/machine-id:/var/lib/dbus/machine-id \
@@ -21,6 +24,7 @@ docker run -d --restart=always --name=kubeletd --network=host --pid=host --uts=h
     --mount type=bind,src=/var/lib/kubelet,dst=/var/lib/kubelet,bind-propagation=rshared \
     -v /var/log/pods:/var/log/pods \
     -v /etc/kubernetes:/etc/kubernetes -v /etc/cni/net.d:/etc/cni/net.d \
+    -v /run/flannel:/run/flannel \
     ${IMAGE}
 
 echo "joining the cluster"


### PR DESCRIPTION
The workflow `nightly-k8s-release-check` will check the newly created releases of repo kubernetes/kubernetes, then create a new issue to start a workflow to build images for them.

Signed-off-by: Kitt Hsu <kitt.hsu@gmail.com>