### PR TITLE
Build images for upgrade upstream LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,44 +42,47 @@ It is available on [cloudtogo4edge/kube-proxy](https://hub.docker.com/r/cloudtog
 
 ### `Compressed / Extracted` Size Matrix
 
-#### v1.24.1
+#### v1.24.2
 
-[`cloudtogo4edge/kubelet v1.24.1`](https://hub.docker.com/r/cloudtogo4edge/kubelet/tags?page=1&ordering=last_updated&name=v1.24.1)
+[`cloudtogo4edge/kubelet v1.24.2`](https://hub.docker.com/r/cloudtogo4edge/kubelet/tags?page=1&ordering=last_updated&name=v1.24.2)
 
 | Tag | amd64 | arm64 | arm32v7 |
 | --- | --- | --- | --- |
-|[`v1.24.1-alpine3.15`]()| `24.75MB / 75.46MB`|`23.28MB / 73.35MB`|`22.79MB / 66.54MB`|
-|[`v1.24.1-flannel-alpine3.15`]()| `29.27MB / 80.07MB`|`27.43MB / 77.60MB`|`27.04MB / 70.90MB`|
-|[`v1.24.1-cni-alpine3.15`]()| `42.39MB / 93.47MB`|`39.45MB / 89.95MB`|`39.29MB / 83.47MB`|
-|[`v1.24.1-kubeadm-alpine3.15`]()| `42.94MB / 94.24MB`|`38.89MB / 89.58MB`|`37.67MB / 82.00MB`|
-|[`v1.24.1-kubeadm-cni-alpine3.15`]()| `60.57MB / 112.24MB`|`55.06MB / 106.17MB`|`54.17MB / 98.92MB`|
+|[`v1.24.2-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.24.2-flannel-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.24.2-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.24.2-kubeadm-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|` 0MB / 0MB`|
+|[`v1.24.2-kubeadm-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+
 #### v1.23.8
 
 [`cloudtogo4edge/kubelet v1.23.8`](https://hub.docker.com/r/cloudtogo4edge/kubelet/tags?page=1&ordering=last_updated&name=v1.23.8)
 
 | Tag | amd64 | arm64 | arm32v7 |
 | --- | --- | --- | --- |
-|[`v1.23.8-alpine3.15`]()| `25.47MB / 77.82MB`|`23.94MB / 75.58MB`|`23.47MB / 68.71MB`|
-|[`v1.23.8-flannel-alpine3.15`]()| `29.99MB / 82.43MB`|`28.08MB / 79.82MB`|`27.72MB / 73.07MB`|
-|[`v1.23.8-cni-alpine3.15`]()| `43.10MB / 95.82MB`|`40.11MB / 92.17MB`|`39.97MB / 85.64MB`|
-|[`v1.23.8-kubeadm-alpine3.15`]()| `44.77MB / 97.77MB`|`40.45MB / 92.78MB`|`39.13MB / 85.02MB`|
-|[`v1.23.8-kubeadm-cni-alpine3.15`]()| `62.41MB / 115.78MB`|`56.62MB / 109.37MB`|`55.64MB / 101.94MB`|
+|[`v1.23.8-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.23.8-flannel-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.23.8-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.23.8-kubeadm-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|` 0MB / 0MB`|
+|[`v1.23.8-kubeadm-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+
 #### v1.22.11
 
 [`cloudtogo4edge/kubelet v1.22.11`](https://hub.docker.com/r/cloudtogo4edge/kubelet/tags?page=1&ordering=last_updated&name=v1.22.11)
 
 | Tag | amd64 | arm64 | arm32v7 |
 | --- | --- | --- | --- |
-|[`v1.22.11-alpine3.15`]()| `24.73MB / 74.71MB`|`23.32MB / 72.51MB`|`22.75MB / 65.52MB`|
-|[`v1.22.11-flannel-alpine3.15`]()| `29.24MB / 79.32MB`|`27.46MB / 76.76MB`|`27.00MB / 69.88MB`|
-|[`v1.22.11-cni-alpine3.15`]()| `42.36MB / 92.71MB`|`39.48MB / 89.11MB`|`39.25MB / 82.45MB`|
-|[`v1.22.11-kubeadm-alpine3.15`]()| `43.79MB / 94.42MB`|`39.63MB / 89.50MB`|`38.25MB / 81.66MB`|
-|[`v1.22.11-kubeadm-cni-alpine3.15`]()| `61.43MB / 112.42MB`|`55.80MB / 106.10MB`|`54.75MB / 98.59MB`|
+|[`v1.22.11-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.22.11-flannel-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.22.11-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+|[`v1.22.11-kubeadm-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|` 0MB / 0MB`|
+|[`v1.22.11-kubeadm-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
+
 #### Alpine 3.13 based kube-proxy image
 
 [`cloudtogo4edge/kube-proxy`](https://hub.docker.com/r/cloudtogo4edge/kube-proxy)
 
-* [`v1.24.1-alpine3.15`]()
+* [`v1.24.2-alpine3.15`]()
 * [`v1.23.8-alpine3.15`]()
 * [`v1.22.11-alpine3.15`]()
 

--- a/README.md
+++ b/README.md
@@ -48,36 +48,33 @@ It is available on [cloudtogo4edge/kube-proxy](https://hub.docker.com/r/cloudtog
 
 | Tag | amd64 | arm64 | arm32v7 |
 | --- | --- | --- | --- |
-|[`v1.24.2-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.24.2-flannel-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.24.2-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.24.2-kubeadm-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|` 0MB / 0MB`|
-|[`v1.24.2-kubeadm-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-
+|[`v1.24.2-alpine3.15`]()| `24.76MB / 75.47MB`|`23.29MB / 73.36MB`|`22.79MB / 66.55MB`|
+|[`v1.24.2-flannel-alpine3.15`]()| `29.28MB / 80.08MB`|`27.43MB / 77.61MB`|`27.04MB / 70.91MB`|
+|[`v1.24.2-cni-alpine3.15`]()| `42.39MB / 93.48MB`|`39.46MB / 89.96MB`|`39.29MB / 83.48MB`|
+|[`v1.24.2-kubeadm-alpine3.15`]()| `42.94MB / 94.25MB`|`38.89MB / 89.59MB`|`37.67MB / 82.01MB`|
+|[`v1.24.2-kubeadm-cni-alpine3.15`]()| `60.58MB / 112.25MB`|`55.06MB / 106.19MB`|`54.17MB / 98.94MB`|
 #### v1.23.8
 
 [`cloudtogo4edge/kubelet v1.23.8`](https://hub.docker.com/r/cloudtogo4edge/kubelet/tags?page=1&ordering=last_updated&name=v1.23.8)
 
 | Tag | amd64 | arm64 | arm32v7 |
 | --- | --- | --- | --- |
-|[`v1.23.8-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.23.8-flannel-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.23.8-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.23.8-kubeadm-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|` 0MB / 0MB`|
-|[`v1.23.8-kubeadm-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-
+|[`v1.23.8-alpine3.15`]()| `25.47MB / 77.82MB`|`23.94MB / 75.58MB`|`23.47MB / 68.71MB`|
+|[`v1.23.8-flannel-alpine3.15`]()| `29.99MB / 82.43MB`|`28.08MB / 79.82MB`|`27.72MB / 73.07MB`|
+|[`v1.23.8-cni-alpine3.15`]()| `43.10MB / 95.82MB`|`40.11MB / 92.17MB`|`39.97MB / 85.64MB`|
+|[`v1.23.8-kubeadm-alpine3.15`]()| `44.77MB / 97.77MB`|`40.45MB / 92.78MB`|`39.13MB / 85.02MB`|
+|[`v1.23.8-kubeadm-cni-alpine3.15`]()| `62.41MB / 115.78MB`|`56.62MB / 109.37MB`|`55.64MB / 101.94MB`|
 #### v1.22.11
 
 [`cloudtogo4edge/kubelet v1.22.11`](https://hub.docker.com/r/cloudtogo4edge/kubelet/tags?page=1&ordering=last_updated&name=v1.22.11)
 
 | Tag | amd64 | arm64 | arm32v7 |
 | --- | --- | --- | --- |
-|[`v1.22.11-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.22.11-flannel-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.22.11-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-|[`v1.22.11-kubeadm-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|` 0MB / 0MB`|
-|[`v1.22.11-kubeadm-cni-alpine3.15`]()| `0MB / 0MB`|`0MB / 0MB`|`0MB / 0MB`|
-
+|[`v1.22.11-alpine3.15`]()| `24.73MB / 74.71MB`|`23.32MB / 72.51MB`|`22.75MB / 65.52MB`|
+|[`v1.22.11-flannel-alpine3.15`]()| `29.24MB / 79.32MB`|`27.46MB / 76.76MB`|`27.00MB / 69.88MB`|
+|[`v1.22.11-cni-alpine3.15`]()| `42.36MB / 92.71MB`|`39.48MB / 89.11MB`|`39.25MB / 82.45MB`|
+|[`v1.22.11-kubeadm-alpine3.15`]()| `43.79MB / 94.42MB`|`39.63MB / 89.50MB`|`38.25MB / 81.66MB`|
+|[`v1.22.11-kubeadm-cni-alpine3.15`]()| `61.43MB / 112.42MB`|`55.80MB / 106.10MB`|`54.75MB / 98.59MB`|
 #### Alpine 3.13 based kube-proxy image
 
 [`cloudtogo4edge/kube-proxy`](https://hub.docker.com/r/cloudtogo4edge/kube-proxy)


### PR DESCRIPTION
This issue is created by a periodically running robot, for building images of the latest kubernetes LTS.